### PR TITLE
Format output using replete pprint

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
            org.clojure/test.check      {:mvn/version "0.10.0-alpha4"}
 
            replete-repl/replete-shared {:git/url "https://github.com/replete-repl/replete-shared.git"
-                                        :sha     "048ee98d7966a49a3dc88eef4dfa9e2c9d0e1211"}
+                                        :sha     "b1dbbb69fa9d998b0e1d069f5a0a52b8a49b2fce"}
 
            re-frame                    {:mvn/version "0.10.6"}
            re-com                      {:mvn/version "2.3.0" :exclusions [org.clojure/core.async]}

--- a/src/replete/cm.cljs
+++ b/src/replete/cm.cljs
@@ -8,7 +8,8 @@
             [reagent.core :as reagent]
             [reagent.dom :as dom]
             [re-frame.core :as re-frame]
-            [replete.events :as events]))
+            [replete.events :as events]
+            [replete.pprint :as pprint]))
 
 (defn cm-parinfer
   [dom-node opts]
@@ -22,11 +23,24 @@
     (js/parinferCodeMirror.init code-mirror)
     code-mirror))
 
+(defmulti render-val :tag)
+
+(defmethod render-val :ret
+  [{:keys [val ns]}]
+  (with-out-str (pprint/pprint val
+                  {:width 70                                ; TODO determine character-width of screen
+                   :ns    ns
+                   :theme "plain"})))
+
+(defmethod render-val :default
+  [prepl-result]
+  (str (:val prepl-result)))
+
 (defn parse-result
   [prepl-result]
-  (when-let [{:keys [form val]} prepl-result]
+  (when-let [{:keys [form]} prepl-result]
     (str (and form (str form "\n"))
-         val "\n\n")))
+         (render-val prepl-result) "\n\n")))
 
 (defn cmirror-comp
   [opts]


### PR DESCRIPTION
Hey @raymcdermott this PR isn't really meant to be merged as it is just exploring an idea.

It appears that values are rendered by first converting them to strings using `str`. But, that skips the Replete value pretty-printing subsystem. A consequence of that is that forms are not wrapped using Fipp, certain Replete formatting things, like the way `(atom 1)` is rendered, abbreviations for Vars and keywords, etc., are skipped. You can also see this if you macroexpand a form: Instead of data, you see a string.

This PR explores hooking value formatting back into the Replete pretty-printing infrastructure.

From the big picture, it seem that the way Replete Web is structured, it ends up in the position it is in because it is using the pREPL interface, where it only has values to render, but maybe it is possible to use Replete to help render those values.