### PR TITLE
Feature/form highlights

### DIFF
--- a/resources/public/css/replete-web.css
+++ b/resources/public/css/replete-web.css
@@ -1,0 +1,8 @@
+.parinfer-error {
+    background: #FFBEBE;
+    color: black !important;
+}
+
+.parinfer-paren-trail {
+    opacity: 0.4;
+}

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset='utf-8'>
     <link rel="shortcut icon" href="images/favicon.png" type="image/png">
+    <link rel="stylesheet" href="css/replete-web.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="vendor/css/codemirror.css">
     <link rel="stylesheet" href="vendor/css/show-hint.css">
@@ -12,6 +14,7 @@
           type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,300" rel="stylesheet" type="text/css">
 </head>
+
 <body>
 <title>REPLETE</title>
 <div id="app"></div>

--- a/src/replete/README.md
+++ b/src/replete/README.md
@@ -32,29 +32,20 @@ Any exceptions / errors should be formatted using parinfer. (TBC)
 - each map has a `:form` key for the input that was evaluated
 
 ## Implementation
-After examining other options we are implementing this formatting with a
-side-effecting `loop recur`
+We parse the prepl-response for the input form parts and the output parts.
 
-This enables the codemirror document to be initialised with the preamble, 
-have each of the PREPL responses formatted appropriately and then 
-finally have the codemirror document swapped once the loop is complete.
+We append results to the CodeMirror instance and calculate the needed 
+markup coordinates for the input form (start line, end line, width).
 
-The process can be optimised by keeping a copy of previously computed state.
+Appending the results requires us to call `.setValue` on the CodeMirror instance.
 
-Other options do not have the ability to directly associate the state of
-the document formatting with the element being processed or seemed off for
-some other reason
+Whenever `.setValue` is called, the existing markup is removed
 
-Other options considered and why they were rejected:
-- formatting post-hoc: blind programming, brittle
-- string tagging: mixing concerns, brittle
-- cm API extensions: not Clojure and too hard to maintain
-- stateful transducer: we need more side-effects than results, no parallelism
+To countermeasure this we keep a history of markup coordinates and apply the markup 
+after any calls to `.setValue`
+
+Yes, managing state is annoying
 
 
 
 
-
-
-
-    

--- a/src/replete/README.md
+++ b/src/replete/README.md
@@ -1,0 +1,60 @@
+# REPLETE output formatting
+The REPLETE repl has some standards to ensure a common experience 
+across each of the platforms on which it is implemented.
+
+The info here refers to the standard `light` mode. 
+
+The inverse rules should be applied for `dark` mode.
+
+## Preamble
+The repl starts each session with a standard text declaring the CLJS version
+in use and some of the affordances of the REPL.
+
+The preamble should be formatted in a clearly muted, dark gray.
+
+## Form / Response
+The input form should be formatted in a clearly muted, dark gray.
+
+Any output and the return value should be formatted using parinfer.
+
+## Exceptions / Errors
+Any exceptions / errors should be formatted using parinfer. (TBC)
+
+### PREPL Results
+- each PREPL response is a sequence of maps
+- the sequence is at least one
+- the sequence has a `:tag` to denote the map data
+  - `:out` is ouput - can be `0..N`
+  - `:err` is an error - there can be `0|1`
+  - `:ret` is the result - there can be `0|1`
+- there is always a `:err` or a `:ret` map
+- each map has a `:val` key for the value associated with the tag
+- each map has a `:form` key for the input that was evaluated
+
+## Implementation
+After examining other options we are implementing this formatting with a
+side-effecting `loop recur`
+
+This enables the codemirror document to be initialised with the preamble, 
+have each of the PREPL responses formatted appropriately and then 
+finally have the codemirror document swapped once the loop is complete.
+
+The process can be optimised by keeping a copy of previously computed state.
+
+Other options do not have the ability to directly associate the state of
+the document formatting with the element being processed or seemed off for
+some other reason
+
+Other options considered and why they were rejected:
+- formatting post-hoc: blind programming, brittle
+- string tagging: mixing concerns, brittle
+- cm API extensions: not Clojure and too hard to maintain
+- stateful transducer: we need more side-effects than results, no parallelism
+
+
+
+
+
+
+
+    

--- a/src/replete/cm.cljs
+++ b/src/replete/cm.cljs
@@ -4,13 +4,7 @@
             [cljsjs.codemirror.addon.hint.show-hint]
             [cljsjs.codemirror.mode.clojure]
             [cljsjs.parinfer]
-            [cljsjs.parinfer-codemirror]
-            [clojure.string :as string]
-            [reagent.core :as reagent]
-            [reagent.dom :as dom]
-            [re-frame.core :as re-frame]
-            [replete.events :as events]
-            [replete.pprint :as pprint]))
+            [cljsjs.parinfer-codemirror]))
 
 (defn cm-parinfer
   [dom-node opts]
@@ -21,127 +15,7 @@
                                        :mode          :clojure}
                                       opts)))]
     (.setSize code-mirror "100%" "100%")
-    (js/parinferCodeMirror.init code-mirror)
+    (.init js/parinferCodeMirror code-mirror)
+
     code-mirror))
 
-(defmulti render-val :tag)
-
-(defmethod render-val :ret
-  [{:keys [val ns]}]
-  (with-out-str (pprint/pprint val
-                               {:width 70                   ; TODO determine character-width of screen
-                                :ns    ns
-                                :theme "plain"})))
-
-(defmethod render-val :default
-  [prepl-result]
-  (:val prepl-result))
-
-;; TODO: how to ensure codemirror uses parinfer rendering for
-;; TODO: showing values and plainer formatting for other text?
-(defn parse-update
-  [eval-update]
-  (cond
-    (:preamble eval-update)
-    (str (:preamble eval-update) "\n\n")
-
-    (coll? eval-update)
-    (str (:form (first eval-update))
-         "\n"
-         (apply str (map :val eval-update))
-         "\n\n")))
-
-(defn save-form
-  [clojure-form]
-  (re-frame/dispatch
-    [::events/save-form clojure-form]))
-
-(defn cmirror-eval-comp
-  [opts]
-  (let [cmirror (atom nil)
-        history (atom [])
-        node-id (:node-id opts)
-        cm-update (fn [comp]
-                    (let [output (parse-update (:changes (reagent/props comp)))]
-                      (swap! history conj output)
-                      (.setValue @cmirror (apply str @history))
-                      (.scrollIntoView @cmirror #js {:line (.lastLine @cmirror)})))]
-    (reagent/create-class
-      {:reagent-render
-       (fn cm-render []
-         [:textarea {:id node-id :auto-complete :off}])
-
-       :component-did-mount
-       (fn cm-did-mount [comp]
-         (let [node (dom/dom-node comp)
-               cm-opts (:cm-options opts)
-               cm (cm-parinfer node cm-opts)]
-           (reset! cmirror cm))
-         (cm-update comp))
-
-       :component-will-unmount
-       (fn cm-will-unmount []
-         (.toTextArea @cmirror)
-         (reset! cmirror nil))
-
-       :component-did-update
-       cm-update
-
-       :display-name
-       node-id})))
-
-(defn enter-binding
-  [enter]
-  (assoc {} enter #(re-frame/dispatch [::events/eval])))
-
-(defn up-binding
-  [up]
-  (assoc {} up #(re-frame/dispatch [::events/history-prev])))
-
-(defn down-binding
-  [down]
-  (assoc {} down #(re-frame/dispatch [::events/history-next])))
-
-(defn cmirror-edit-comp
-  [opts]
-  (let [cmirror (atom nil)
-        node-id (:node-id opts)
-        cm-update (fn [comp]
-                    (when-let [changes (:changes (reagent/props comp))]
-                      (if (:clear-input-form changes)
-                        (.setValue @cmirror "")
-                        (.setValue @cmirror changes))))]
-    (reagent/create-class
-      {:reagent-render
-       (fn cm-render
-         []
-         [:textarea {:id node-id :auto-complete :off}])
-
-       :component-did-mount
-       (fn cm-did-mount
-         [comp]
-         (let [node (dom/dom-node comp)
-               enter (enter-binding (get-in opts [:key-bindings :enter]))
-               down (down-binding (get-in opts [:key-bindings :down]))
-               up (up-binding (get-in opts [:key-bindings :up]))
-               editor-shortcut {:extraKeys (merge enter up down)}
-               cm-opts (merge (:cm-options opts) editor-shortcut)
-               cm (cm-parinfer node cm-opts)]
-           (.on cm "change" (fn [cm _]
-                              (let [val (string/trim (.getValue cm))]
-                                (when-not (empty? val)
-                                  (save-form val)))))
-           (reset! cmirror cm))
-         (cm-update comp))
-
-       :component-will-unmount
-       (fn cm-will-unmount
-         []
-         (.toTextArea @cmirror)
-         (reset! cmirror nil))
-
-       :component-did-update
-       cm-update
-
-       :display-name
-       node-id})))

--- a/src/replete/cm_edit.cljs
+++ b/src/replete/cm_edit.cljs
@@ -1,0 +1,74 @@
+(ns replete.cm-edit
+  (:require [cljsjs.codemirror]
+            [cljsjs.codemirror.addon.edit.matchbrackets]
+            [cljsjs.codemirror.addon.hint.show-hint]
+            [cljsjs.codemirror.mode.clojure]
+            [cljsjs.parinfer]
+            [cljsjs.parinfer-codemirror]
+            [clojure.string :as string]
+            [reagent.core :as reagent]
+            [reagent.dom :as dom]
+            [re-frame.core :as re-frame]
+            [replete.cm :as cm]
+            [replete.events :as events]))
+
+(defn save-form
+  [clojure-form]
+  (re-frame/dispatch
+    [::events/save-form clojure-form]))
+
+(defn enter-binding
+  [enter]
+  (assoc {} enter #(re-frame/dispatch [::events/eval])))
+
+(defn up-binding
+  [up]
+  (assoc {} up #(re-frame/dispatch [::events/history-prev])))
+
+(defn down-binding
+  [down]
+  (assoc {} down #(re-frame/dispatch [::events/history-next])))
+
+(defn cmirror-edit-comp
+  [opts]
+  (let [cmirror (atom nil)
+        node-id (:node-id opts)
+        cm-update (fn [comp]
+                    (when-let [changes (:changes (reagent/props comp))]
+                      (if (:clear-input-form changes)
+                        (.setValue @cmirror "")
+                        (.setValue @cmirror changes))))]
+    (reagent/create-class
+      {:reagent-render
+       (fn cm-render
+         []
+         [:textarea {:id node-id :auto-complete :off}])
+
+       :component-did-mount
+       (fn cm-did-mount
+         [comp]
+         (let [node (dom/dom-node comp)
+               enter (enter-binding (get-in opts [:key-bindings :enter]))
+               down (down-binding (get-in opts [:key-bindings :down]))
+               up (up-binding (get-in opts [:key-bindings :up]))
+               editor-shortcut {:extraKeys (merge enter up down)}
+               cm-opts (merge (:cm-options opts) editor-shortcut)
+               cm (cm/cm-parinfer node cm-opts)]
+           (.on cm "change" (fn [cm _]
+                              (let [val (string/trim (.getValue cm))]
+                                (when-not (empty? val)
+                                  (save-form val)))))
+           (reset! cmirror cm))
+         (cm-update comp))
+
+       :component-will-unmount
+       (fn cm-will-unmount
+         []
+         (.toTextArea @cmirror)
+         (reset! cmirror nil))
+
+       :component-did-update
+       cm-update
+
+       :display-name
+       node-id})))

--- a/src/replete/cm_eval.cljs
+++ b/src/replete/cm_eval.cljs
@@ -1,0 +1,162 @@
+(ns replete.cm-eval
+  (:require [cljsjs.codemirror]
+            [cljsjs.codemirror.addon.edit.matchbrackets]
+            [cljsjs.codemirror.addon.hint.show-hint]
+            [cljsjs.codemirror.mode.clojure]
+            [cljsjs.parinfer]
+            [cljsjs.parinfer-codemirror]
+            [clojure.string :as string]
+            [reagent.core :as reagent]
+            [reagent.dom :as dom]
+            [re-frame.core :as re-frame]
+            [replete.cm :as cm]
+            [replete.events :as events]
+            [replete.pprint :as pprint]))
+
+(defmulti render-val :tag)
+
+(defmethod render-val :ret
+  [{:keys [val ns]}]
+  (with-out-str (pprint/pprint val
+                               {:width 70                   ; TODO determine character-width of screen
+                                :ns    ns
+                                :theme "plain"})))
+
+(defmethod render-val :default
+  [prepl-result]
+  (:val prepl-result))
+
+(defn select-regex-keys
+  [data regex]
+  (select-keys
+    data
+    (filter (fn [k]
+              (let [n (name k)]
+                (re-find regex n)))
+            (keys data))))
+
+(defn max-line-width
+  "The maximum width of lines in `s` or 0 if `s` is nil"
+  [s]
+  (or (some->> s
+               clojure.string/split-lines
+               (map count)
+               (reduce max))
+      0))
+
+(defn lines-count
+  "The count of lines in `s` or 0 if `s` is nil"
+  [s]
+  (or (some-> s clojure.string/split-lines count) 0))
+
+(defn lines-key-data
+  "A map from val kw
+   {:kw-lines-count #lines
+    :kw-lines-width (max of any lines in val)}"
+  [val kw]
+  (let [lines-count (lines-count val)
+        lines-width (max-line-width val)]
+    (assoc {}
+      (keyword (str (name kw) "-lines-count")) lines-count
+      (keyword (str (name kw) "-lines-width")) lines-width)))
+
+(defn lines-data
+  "A map of lines information for each key data"
+  [data]
+  (let [keys (keys data)]
+    (apply merge (map (fn [k]
+                        (lines-key-data (get data k) k))
+                      keys))))
+
+;(def form-gap "\n")
+;(def result-gap "\n\n")
+
+(def preamble-text
+  (str "ClojureScript " *clojurescript-version*
+       "\n    Docs : (doc function-name)"
+       "\n           (find-doc \"part-of-name\")"
+       "\n  Source : (source function-name)"
+       "\n Results : Stored in *1, *2, *3,"
+       "\n           an exception in *e\n\n"))
+
+(def replete-dim-css "color: #282828")
+
+(defn mark-up-preamble
+  [cm]
+  (let [width (max-line-width preamble-text)
+        end-line (lines-count preamble-text)]
+    (.markText cm
+               #js {:line 0 :ch 0}
+               #js {:line end-line :ch width}
+               #js {:css replete-dim-css})))
+
+(defn parse-prepl-response
+  [prepl-response]
+  {:form       (:form (first prepl-response))
+   :form-gap   "\n"
+   :output     (->> prepl-response
+                    (map :val)
+                    (apply str)
+                    clojure.string/trim-newline)
+   :result-gap "\n\n"})
+
+(defn mark-up-inputform
+  [cm {:keys [start end width]}]
+  (.markText cm
+             #js {:line start :ch 0}
+             #js {:line end :ch width}
+             #js {:css replete-dim-css}))
+
+(defn mark-up-results
+  [cm mark-up-directions]
+  (doall (map (partial mark-up-inputform cm) mark-up-directions)))
+
+(defn render-prepl-response
+  "Render the PREPL results and return markup data for forms"
+  [cm prepl-response]
+  (let [cm-value (.getValue cm)
+        form-start (.lastLine cm)
+        {:keys [form form-gap output result-gap]} (parse-prepl-response prepl-response)]
+    (.setValue cm (str cm-value form))
+    (let [form-end (.lastLine cm)
+          form-width (max-line-width form)
+          response (str form-gap output result-gap)]
+      (.setValue cm (str (.getValue cm) response))
+      {:start form-start :end form-end :width form-width})))
+
+(defn cmirror-eval-comp
+  [opts]
+  (let [cmirror (atom nil)
+        node-id (:node-id opts)
+        mark-up (atom [])
+        cm-update (fn [comp]
+                    (when-let [changes (:changes (reagent/props comp))]
+                      (swap! mark-up conj (render-prepl-response @cmirror changes))
+                      (mark-up-preamble @cmirror)
+                      (mark-up-results @cmirror @mark-up)
+                      (.scrollIntoView @cmirror #js {:line (.lastLine @cmirror)})))]
+    (reagent/create-class
+      {:reagent-render
+       (fn cm-render []
+         [:textarea {:id node-id :auto-complete :off}])
+
+       :component-did-mount
+       (fn cm-did-mount [comp]
+         (let [node (dom/dom-node comp)
+               cm-opts (:cm-options opts)
+               cm (cm/cm-parinfer node cm-opts)]
+           (.setValue cm preamble-text)
+           (mark-up-preamble cm)
+           (reset! cmirror cm))
+         (cm-update comp))
+
+       :component-will-unmount
+       (fn cm-will-unmount []
+         (.toTextArea @cmirror)
+         (reset! cmirror nil))
+
+       :component-did-update
+       cm-update
+
+       :display-name
+       node-id})))

--- a/src/replete/editor.cljs
+++ b/src/replete/editor.cljs
@@ -4,7 +4,8 @@
     [re-com.core :refer [h-box v-box box button gap line scroller
                          border label input-text v-split md-icon-button
                          input-textarea title flex-child-style p slider]]
-    [replete.cm :as cmirror]
+    [replete.cm-edit :as cm-edit]
+    [replete.cm-eval :as cm-eval]
     [replete.events :as events]
     [replete.subs :as subs]))
 
@@ -27,21 +28,20 @@
                   :cm-options   {:autofocus true}}]
         [box
          :style box-style
-         :child [cmirror/cmirror-edit-comp opts]]))))
+         :child [cm-edit/cmirror-edit-comp opts]]))))
 
 (defn eval-mirror
   "Show evalled results from the component it is `watching`"
   []
-  (let [preamble (re-frame/subscribe [::subs/preamble])
-        result (re-frame/subscribe [::subs/eval-result])]
+  (let [result (re-frame/subscribe [::subs/eval-result])]
     (fn []
       (let [opts {:editor?    false
                   :node-id    "eval-history"
                   :cm-options {:readOnly true}
-                  :changes    (or @result @preamble)}]
+                  :changes    @result}]
         [box
          :style box-style
-         :child [cmirror/cmirror-eval-comp opts]]))))
+         :child [cm-eval/cmirror-eval-comp opts]]))))
 
 (defn button-label
   [os]

--- a/src/replete/events.cljs
+++ b/src/replete/events.cljs
@@ -7,15 +7,6 @@
                                    reg-event-fx
                                    reg-fx]]))
 
-(defonce
-  preamble
-  (str "ClojureScript " *clojurescript-version*
-       "\n    Docs : (doc function-name)"
-       "\n           (find-doc \"part-of-name\")"
-       "\n  Source : (source function-name)"
-       "\n Results : Stored in *1, *2, *3,"
-       "\n           an exception in *e"))
-
 (defn key-bindings
   [os]
   (let [ckey (if (= os :macosx) "cmd" "ctrl")
@@ -44,10 +35,8 @@
 (reg-event-db
   ::initialize-db
   (fn [_ _]
-    (merge
-      {:app-name "replete-web"
-       :preamble {:preamble preamble}}
-      os-data)))
+    (merge {:app-name "replete-web"}
+           os-data)))
 
 (reg-event-db
   ::save-form

--- a/src/replete/subs.cljs
+++ b/src/replete/subs.cljs
@@ -2,11 +2,6 @@
   (:require [re-frame.core :refer [reg-sub]]))
 
 (reg-sub
-  ::preamble
-  (fn [db]
-    (:preamble db)))
-
-(reg-sub
   ::restore-item
   (fn [db]
     (:restore-item db)))


### PR DESCRIPTION
The preamble text and input forms on results is formatted using a dark grey to align the rendering to the other REPLs in the family